### PR TITLE
Run Docker Container as Non-Root User for Improved Security Score

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,15 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy application files
-COPY . . 
+COPY . .
+
+# Create non-root user and set up directories
+RUN groupadd -r appuser && useradd -r -g appuser appuser && \
+    mkdir -p uploads processed && \
+    chown -R appuser:appuser /app
+
+# Switch to non-root user
+USER appuser
 
 # Expose the port
 EXPOSE 5003


### PR DESCRIPTION
Fixes #47

## Changes
- Add non-root user (appuser) to Dockerfile
- Set proper ownership and permissions for application directories
- Switch to non-root user before starting Flask application

## Testing
- Verified container runs as appuser (uid=999, not root)
- Verified all directories owned by appuser:appuser
- Verified uploads/ and processed/ directories have correct permissions
- No permission errors in build process

## Security Impact
- Improves Docker Scout security score
- Reduces attack surface by running with least privileges
- Follows container security best practices