### PR TITLE
Fix Safety CLI Authentication in CI Workflows

### DIFF
--- a/.github/workflows/dependabot-weekly.yml
+++ b/.github/workflows/dependabot-weekly.yml
@@ -108,6 +108,7 @@ jobs:
           pip install safety bandit
           
           # Check for known security vulnerabilities
+          export SAFETY_API_KEY="${{ secrets.SAFETY_API_KEY }}"
           safety scan || true
           
           # Static security analysis

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -93,6 +93,8 @@ jobs:
           bandit -r . -f json -o bandit-report.json -x tests/ || true
 
       - name: 🛡️ Dependency security check
+        env:
+          SAFETY_API_KEY: ${{ secrets.SAFETY_API_KEY }}
         run: safety scan || true
 
   # 🏢 Production LEGO Assembly Line

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -196,6 +196,8 @@ jobs:
           bandit -r . -f json -o bandit-report.json -x tests/ || true
 
       - name: Dependency security check
+        env:
+          SAFETY_API_KEY: ${{ secrets.SAFETY_API_KEY }}
         run: safety scan || true
 
   # 🛡️ CodeQL Security Analysis (parallel)


### PR DESCRIPTION
## Summary
Fixes the Safety CLI authentication issue in GitHub Actions workflows where `safety scan` was failing with interactive login prompts.

## Changes
- Added `SAFETY_API_KEY` environment variable to all Safety scan steps in:
  - `.github/workflows/pr-quality-gate.yml`
  - `.github/workflows/docker-publish.yml`
  - `.github/workflows/dependabot-weekly.yml`

## What This Fixes
The Safety CLI now requires authentication for the `scan` command. Without proper API key configuration, it attempts to prompt for interactive login, which fails in CI environments with:
```
Please login or register Safety CLI (free forever) to scan and secure your projects with Safety
(R)egister for a free account in 30 seconds, or (L)ogin with an existing account
Unhandled exception happened: EOF when reading a line
```

## Requirements
This change requires the `SAFETY_API_KEY` secret to be configured in the repository settings. The workflow will continue to use `|| true` to prevent CI failures if the secret is not set, but will properly authenticate and upload results when the key is available.

## Testing
- Workflows will run on this PR to validate the changes
- Once merged and SAFETY_API_KEY is configured, Safety scans will authenticate and upload results to your Safety account