### PR TITLE
fix(security): pin nltk==3.9.3 to remediate CVE-2025-14009 (CRITICAL)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,5 @@ pytest-asyncio==1.3.0
 # Development dependencies
 pylint==4.0.4
 safety==3.7.0
+nltk==3.9.3  # Pin to fix CVE-2025-14009 (Zip Slip) - transitive dep via safety
 bandit==1.9.3


### PR DESCRIPTION
## Security Fix 🔴 CRITICAL

Fixes Dependabot alert #17.

## Vulnerability
- **CVE:** CVE-2025-14009
- **Package:** nltk (transitive dependency via `safety`)
- **Severity:** CRITICAL
- **Issue:** Zip Slip vulnerability — allows arbitrary file write via path traversal in zip extraction
- **Affected versions:** <= 3.9.2
- **Fixed in:** 3.9.3

## Change
Pinned `nltk==3.9.3` explicitly in `requirements.txt` to override the vulnerable transitive version pulled in by `safety==3.7.0`.

## References
- https://github.com/BondIT-ApS/open-xliff-translator/security/dependabot/17
- https://github.com/advisories/GHSA-7p94-766c-hgjp