### PR TITLE
chore: dependabot rollup — 6 dependency updates (Apr 2026)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -93,7 +93,7 @@ jobs:
           pytest -v --cov=app --cov-report=xml --cov-report=term-missing
 
       - name: 📊 Upload coverage to CodeCov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -196,7 +196,7 @@ jobs:
           pytest -v --cov=app --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage to CodeCov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # FastAPI and ASGI server
-fastapi==0.135.1
+fastapi==0.135.2
 uvicorn[standard]==0.41.0
 
 # Async HTTP client

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,5 +27,5 @@ pytest-asyncio==1.3.0
 # Development dependencies
 pylint==4.0.5
 safety==3.7.0
-nltk==3.9.3  # Pin to fix CVE-2025-14009 (Zip Slip) - transitive dep via safety
+nltk==3.9.4  # Pin to fix CVE-2025-14009 (Zip Slip) - transitive dep via safety
 bandit==1.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ uvicorn[standard]==0.41.0
 httpx==0.28.1
 
 # Configuration management
-python-dotenv==1.2.1
+python-dotenv==1.2.2
 pydantic-settings==2.13.1
 
 # Security - XML parsing and file handling

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # FastAPI and ASGI server
 fastapi==0.135.1
-uvicorn[standard]==0.41.0
+uvicorn[standard]==0.42.0
 
 # Async HTTP client
 httpx==0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ jinja2==3.1.6
 
 # Testing dependencies
 pytest==9.0.2
-pytest-cov==7.0.0
+pytest-cov==7.1.0
 pytest-asyncio==1.3.0
 
 # Development dependencies


### PR DESCRIPTION
## Dependabot Rollup — April 2026

Consolidates all 6 open Dependabot PRs into a single merge-ready branch.

Closes #100

### Changes

**`requirements.txt`**
| Package | From | To | PR |
|---|---|---|---|
| `fastapi` | 0.135.1 | 0.135.2 | #97 |
| `uvicorn[standard]` | 0.41.0 | 0.42.0 | #94 |
| `python-dotenv` | 1.2.1 | 1.2.2 | #95 |
| `pytest-cov` | 7.0.0 | 7.1.0 | #98 |
| `nltk` | 3.9.3 | 3.9.4 | #99 |

**GitHub Actions**
| Action | From | To | PR |
|---|---|---|---|
| `codecov/codecov-action` | v5 | v6 | #101 |

### Merge conflicts resolved

PR #97 (fastapi) conflicted with PR #94 (uvicorn) because both Dependabot branches diverged from `main` before the other was applied. Resolved by keeping both the newer fastapi (0.135.2) and the newer uvicorn (0.42.0) in the merged result.

### Validation

- **Tests:** 47/47 passed, 84% coverage
- **Pylint:** 9.96/10 (pre-existing `invalid-name` convention note, not introduced by these updates)
- **Docker build:** Successful
- **Docker run:** Both containers healthy (`open-xliff-translator` + `open-xliff-libretranslate`)
- **Endpoints verified:**
  - `GET /health` → `{"status":"healthy","libretranslate":"available","filesystem":"writable"}`
  - `GET /` → HTTP 200
  - LibreTranslate `/languages` → `["en", "da"]` ✓