### PR TITLE
chore: consolidate all open Dependabot updates

### DIFF
--- a/.github/workflows/dependabot-weekly.yml
+++ b/.github/workflows/dependabot-weekly.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 🧱 Post Weekly Maintenance Notice
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             // Check if there are any open Dependabot PRs
@@ -154,7 +154,7 @@ jobs:
     
     steps:
       - name: 🎯 Create Maintenance Summary
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const needs = ${{ toJson(needs) }};

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -67,7 +67,7 @@ jobs:
           echo "Detected $LINES_CHANGED lines changed"
 
       - name: 🧱 Post LEGO Building Plan Comment
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const linesChanged = ${{ steps.stats.outputs.lines-changed }};
@@ -318,7 +318,7 @@ jobs:
 
     steps:
       - name: 🎯 Post Quality Gate Results
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const needs = ${{ toJson(needs) }};

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # FastAPI and ASGI server
-fastapi==0.135.2
-uvicorn[standard]==0.42.0
+fastapi==0.135.3
+uvicorn[standard]==0.44.0
 
 # Async HTTP client
 httpx==0.28.1
@@ -11,16 +11,16 @@ pydantic-settings==2.13.1
 
 # Security - XML parsing and file handling
 defusedxml==0.7.1
-werkzeug==3.1.6
+werkzeug==3.1.8
 
 # Form data handling
-python-multipart==0.0.22
+python-multipart==0.0.26
 
 # Templating
 jinja2==3.1.6
 
 # Testing dependencies
-pytest==9.0.2
+pytest==9.0.3
 pytest-cov==7.1.0
 pytest-asyncio==1.3.0
 


### PR DESCRIPTION
## Dependabot Rollup

Consolidates all 7 open Dependabot PRs into a single merge-ready update.

### Python dependency updates (requirements.txt)
- **fastapi** 0.135.2 → 0.135.3 (#109)
- **uvicorn** 0.42.0 → 0.44.0 (#106)
- **werkzeug** 3.1.6 → 3.1.8 (#105)
- **python-multipart** 0.0.22 → 0.0.26 (#112, supersedes #108)
- **pytest** 9.0.2 → 9.0.3 (#112, supersedes #107)

### CI workflow updates
- **actions/github-script** v8 → v9 in `dependabot-weekly.yml` and `pr-quality-gate.yml` (#111)

### PRs superseded
- #108 (python-multipart → 0.0.24) — superseded by #112 which bumps to 0.0.26
- #107 (pytest → 9.0.3) — superseded by #112 which includes the same update

### Maintenance issues
- Closes #116
- Closed #104, #110, #113, #114, #115 with reference to #116

### Validation
- Docker image builds successfully
- No merge conflicts (all PRs touch independent lines)
- No breaking API changes in any of the updated packages