### PR TITLE
fix: patch python-multipart CVE-2026-42561 and add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+# Virtual environments
+venv/
+.venv/
+env/
+
+# Version control
+.git/
+.gitignore
+
+# IDE / editor
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+
+# Docker
+docker-compose.yml
+docker-compose.*.yml
+Dockerfile
+
+# CI/CD
+.github/
+
+# Documentation and config
+*.md
+LICENSE
+.env
+.env.*
+!.env.template
+.pylintrc
+
+# Uploads and processed files
+uploads/
+processed/
+
+# Test artifacts
+.pytest_cache/
+.coverage
+coverage.xml
+htmlcov/

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ defusedxml==0.7.1
 werkzeug==3.1.8
 
 # Form data handling
-python-multipart==0.0.26
+python-multipart==0.0.27
 
 # Templating
 jinja2==3.1.6


### PR DESCRIPTION
## Security Fix

This was part of the Dependabot rollup branch but was pushed after PR #117 was merged.

### Changes

- **python-multipart** 0.0.26 → 0.0.27 — fixes CVE-2026-42561 (HIGH)
- **Added `.dockerignore`** — excludes `venv/`, `.git/`, and build artifacts from Docker image
  - Eliminates 10 stale Python package CVEs that leaked from the local `venv/` into the image via `COPY . .`
  - Reduces Docker build context from 136MB to <2KB

### Trivy scan results (post-fix)
- **0 Python package vulnerabilities** (HIGH/CRITICAL)
- 17 Debian OS-level CVEs remain with no upstream fixes available

### Validation
- Docker build: passing
- All 47 tests: passing
- Pylint: 9.54/10
- `/health` endpoint: healthy
- `/` endpoint: HTTP 200