### PR TITLE
chore(deps): bundle Dependabot sweep + add grouping config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,16 @@ updates:
     commit-message:
       prefix: "deps"
       prefix-development: "deps-dev"
+    groups:
+      # Bundle patch + minor bumps so the weekly run produces one PR per
+      # ecosystem instead of one per dep. Security advisories and majors
+      # still come as individual PRs (Dependabot default).
+      pip-production:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      pip-development:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
 
   # Scan for Docker updates in Dockerfile (root directory)
   - package-ecosystem: "docker"
@@ -19,6 +29,10 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: "docker"
+    groups:
+      docker:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # Include GitHub Actions workflows
   - package-ecosystem: "github-actions"
@@ -28,3 +42,7 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "ci"
+    groups:
+      github-actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,20 @@
 # FastAPI and ASGI server
-fastapi==0.135.3
-uvicorn[standard]==0.44.0
+fastapi==0.136.1
+uvicorn[standard]==0.47.0
 
 # Async HTTP client
 httpx==0.28.1
 
 # Configuration management
 python-dotenv==1.2.2
-pydantic-settings==2.13.1
+pydantic-settings==2.14.1
 
 # Security - XML parsing and file handling
 defusedxml==0.7.1
 werkzeug==3.1.8
 
 # Form data handling
-python-multipart==0.0.27
+python-multipart==0.0.29
 
 # Templating
 jinja2==3.1.6


### PR DESCRIPTION
## Why

Four Dependabot PRs were queued on this repo. Bundling the safe patch + minor bumps into one PR keeps CI runs and reviewer noise down, and adds `groups:` to `.github/dependabot.yml` so this stops piling up weekly.

## Bundled bumps (supersedes #120, #121, #122, #123)

| Package | From | To | Type |
|---|---|---|---|
| fastapi | 0.135.3 | 0.136.1 | minor |
| uvicorn[standard] | 0.44.0 | 0.47.0 | minor |
| pydantic-settings | 2.13.1 | 2.14.1 | minor |
| python-multipart | 0.0.27 | 0.0.29 | patch |

## Verification

- `pip install -r requirements.txt` — clean
- `pytest --no-cov` — **47/47 passed**

## 🧱 Dependabot grouping

Future weekly runs will produce:
- 1 PR for pip production (minor + patch)
- 1 PR for pip development (minor + patch)
- 1 PR for docker (minor + patch)
- 1 PR for github-actions (minor + patch)

Majors and security advisories still arrive as individual PRs.

## Closes

#119 (weekly LEGO maintenance report)
Supersedes #120, #121, #122, #123
