### PR TITLE
fix(deps): apply weekly security digest #130

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # FastAPI and ASGI server
 fastapi==0.136.3
-uvicorn[standard]==0.48.0
+uvicorn[standard]==0.49.0
 
 # Async HTTP client
 httpx==0.28.1
@@ -14,7 +14,7 @@ defusedxml==0.7.1
 werkzeug==3.1.8
 
 # Form data handling
-python-multipart==0.0.29
+python-multipart==0.0.32
 
 # Templating
 jinja2==3.1.6
@@ -26,6 +26,6 @@ pytest-asyncio==1.4.0
 
 # Development dependencies
 pylint==4.0.5
-safety==3.8.0
+safety==3.8.1
 nltk==3.9.4  # Pin to fix CVE-2025-14009 (Zip Slip) - transitive dep via safety
 bandit==1.9.4


### PR DESCRIPTION
## Summary

Apply the weekly security digest from issue #130 by bumping directly-pinned Python dependencies in `requirements.txt`.

### ✅ Applied (direct pins)

| Package | From | To |
|---|---|---|
| uvicorn[standard] | 0.48.0 | 0.49.0 |
| python-multipart | 0.0.29 | 0.0.32 |
| safety | 3.8.0 | 3.8.1 |

### ⏭️ Skipped — transitive (not directly pinned)

These will update automatically when their parent package releases:

- **astroid** — transitive via `pylint`
- **pydantic_core** — transitive via `pydantic-settings`
- **safety-schemas** — transitive via `safety`
- **typer** — transitive via `safety`

Per project policy, only directly-pinned dependencies are bumped; transitive dependencies are not pinned directly to avoid drift from upstream resolution.

Closes #130
